### PR TITLE
feat: terminal action for TCPs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,8 @@
         "superjson": "1.12.3",
         "utf-8-validate": "^6.0.3",
         "xstate": "^4.37.2",
+        "xterm": "^5.3.0",
+        "xterm-addon-fit": "^0.8.0",
         "yaml": "^2.3.1",
         "zod": "^3.24.2",
         "zustand": "^4.3.8"
@@ -55,6 +57,7 @@
         "@types/prettier": "^3.0.0",
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.5",
+        "@types/ws": "^8.18.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.59.11",
         "@vitejs/plugin-react": "^4.3.4",
@@ -6699,8 +6702,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "8.5.4",
-      "license": "MIT",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -19679,6 +19683,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/xterm": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead."
+    },
+    "node_modules/xterm-addon-fit": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
+      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
+      "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "superjson": "1.12.3",
     "utf-8-validate": "^6.0.3",
     "xstate": "^4.37.2",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0",
     "yaml": "^2.3.1",
     "zod": "^3.24.2",
     "zustand": "^4.3.8"
@@ -65,6 +67,7 @@
     "@types/prettier": "^3.0.0",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.5",
+    "@types/ws": "^8.18.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.59.11",
     "@vitejs/plugin-react": "^4.3.4",

--- a/src/app/api/kubectl/cleanup/route.ts
+++ b/src/app/api/kubectl/cleanup/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { unlink } from 'fs/promises';
+import fs from 'fs';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { kubeconfigPath } = await req.json();
+    
+    if (!kubeconfigPath) {
+      return NextResponse.json({ error: 'No path provided' }, { status: 400 });
+    }
+
+    // Check if file exists synchronously first
+    if (!fs.existsSync(kubeconfigPath)) {
+      return NextResponse.json({ success: true }); // File doesn't exist, consider it cleaned
+    }
+    
+    try {
+      // Try to delete the file
+      await unlink(kubeconfigPath);
+      return NextResponse.json({ success: true });
+    } catch (error) {
+      console.error('Error during file deletion:', error);
+      
+      // If file doesn't exist after failed deletion, consider it a success
+      if (!fs.existsSync(kubeconfigPath)) {
+        return NextResponse.json({ success: true });
+      }
+      
+      // Try synchronous deletion as fallback
+      try {
+        fs.unlinkSync(kubeconfigPath);
+        return NextResponse.json({ success: true });
+      } catch (syncError) {
+        console.error('Synchronous deletion failed:', syncError);
+        return NextResponse.json({ 
+          error: 'Failed to cleanup file',
+        }, { status: 500 });
+      }
+    }
+  } catch (error) {
+    console.error('Cleanup request error:', error);
+    return NextResponse.json({ 
+      error: 'Invalid request',
+    }, { status: 400 });
+  }
+} 

--- a/src/app/api/kubectl/route.ts
+++ b/src/app/api/kubectl/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { writeFile, unlink } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const execAsync = promisify(exec);
+
+// Make sure to export the POST handler correctly for Next.js 13+ API routes
+export async function POST(req: NextRequest) {
+  let kubeconfigPath = '';
+  
+  try {
+    const body = await req.json();
+    const { command, kubeconfig } = body;
+
+    if (!command?.startsWith('kubectl ')) {
+      return NextResponse.json(
+        { error: 'Only kubectl commands are allowed' }, 
+        { status: 400 }
+      );
+    }
+
+    if (!kubeconfig) {
+      return NextResponse.json(
+        { error: 'Kubeconfig is required' },
+        { status: 400 }
+      );
+    }
+
+    // Create temporary kubeconfig file with unique name
+    const kubeconfigName = `kubeconfig-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    kubeconfigPath = join(tmpdir(), kubeconfigName);
+    
+    try {
+      // Write the kubeconfig file
+      await writeFile(kubeconfigPath, kubeconfig, { 
+        encoding: 'utf-8',
+        mode: 0o600 // Set proper permissions
+      });
+      
+      // Execute the command
+      const { stdout, stderr } = await execAsync(command, {
+        env: {
+          ...process.env,
+          KUBECONFIG: kubeconfigPath,
+        },
+      });
+
+      return NextResponse.json({ 
+        output: stdout || stderr,
+        kubeconfigPath: kubeconfigPath // Return full path
+      });
+    } catch (error) {
+      console.error('Command execution error:', error);
+      throw error;
+    }
+  } catch (error) {
+    console.error('kubectl execution error:', error);
+    throw error;
+  }
+} 

--- a/src/app/dashboard/(base)/tcps/[namespace]/[name]/page.tsx
+++ b/src/app/dashboard/(base)/tcps/[namespace]/[name]/page.tsx
@@ -10,9 +10,10 @@ import { type IoClastixKamajiV1alpha1TenantControlPlane } from "@/gen/api";
 import { reactApi } from "@/utils/api";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Nodes } from "./nodes";
 import { ReleatedObjects } from "./related-objects";
+import { TerminalComponent } from "@/components/terminal";
 
 interface Params {
   name: string;
@@ -96,6 +97,7 @@ const TopBar = ({
 }) => {
   const editoTcp = useEditTenantControlPlane();
   const deleteTcp = useDeleteTCP();
+  const [showTerminal, setShowTerminal] = useState(false);
 
   return (
     <div className="flex justify-between py-4">
@@ -128,9 +130,42 @@ const TopBar = ({
             >
               Delete
             </button>
+            <button
+              className="btn-primary btn-sm btn"
+              onClick={() => setShowTerminal(!showTerminal)}
+            >
+              Terminal
+            </button>
           </>
         )}
       </div>
+      {showTerminal && (
+        <div 
+          id="kamaji-terminal-container"
+          className="fixed inset-x-0 bottom-0 h-96 bg-black shadow-lg z-50"
+        >
+          <div className="relative w-full h-full flex flex-col">
+            <div className="flex justify-between items-center px-4 py-2 border-b border-gray-700">
+              <div className="text-white opacity-50 text-sm">Terminal</div>
+              <button
+                className="text-gray-400 hover:text-white transition-colors"
+                onClick={() => {
+                  const event = new CustomEvent('terminal-cleanup');
+                  window.dispatchEvent(event);
+                  setShowTerminal(false);
+                }}
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="flex-1 overflow-hidden">
+              {tcp && <TerminalComponent tcp={tcp} onClose={() => setShowTerminal(false)} />}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/actions/tcps/view-kubeconfig.tsx
+++ b/src/components/actions/tcps/view-kubeconfig.tsx
@@ -6,6 +6,7 @@ import { StreamLanguage } from "@codemirror/language";
 import * as yamlMode from "@codemirror/legacy-modes/mode/yaml";
 import CodeMirror from "@uiw/react-codemirror";
 import { EditorView } from "codemirror";
+import type { IoClastixKamajiV1alpha1TenantControlPlane } from "@/gen/api";
 
 interface TCP {
   name: string;

--- a/src/components/terminal/index.tsx
+++ b/src/components/terminal/index.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { reactApi } from "@/utils/api";
+import type { IoClastixKamajiV1alpha1TenantControlPlane } from "@/gen/api";
+
+interface TerminalProps {
+  tcp: IoClastixKamajiV1alpha1TenantControlPlane;
+  onClose?: () => void;
+}
+
+export function TerminalComponent({ tcp, onClose }: TerminalProps) {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState<string[]>([]);
+  const [kubeconfigPath, setKubeconfigPath] = useState<string>("");
+  const [commandHistory, setCommandHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [savedInput, setSavedInput] = useState(""); // Saves current input when navigating history
+  const outputRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<HTMLDivElement>(null);
+
+  const kubeconfig = reactApi.k8s.getClastixTPCKubeConfig.useQuery({
+    name: tcp.metadata?.name || "",
+    namespace: tcp.metadata?.namespace || ""
+  });
+
+  // Scroll to bottom when output changes
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight;
+    }
+  }, [output]);
+
+  // Handle keyboard events
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Clear terminal with Ctrl+L
+      if (e.ctrlKey && e.key.toLowerCase() === "l") {
+        e.preventDefault();
+        setOutput([]);
+        return;
+      }
+
+      // Handle arrow keys for history navigation
+      if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+        e.preventDefault();
+
+        if (commandHistory.length === 0) return;
+
+        const setInputFn = function(cmd: string | undefined) {
+          if (cmd == undefined) {
+            return;
+          }
+
+          setInput(cmd);
+        };
+
+        if (e.key === "ArrowUp") {
+          // Save current input if we're starting to navigate history
+          if (historyIndex === -1) {
+            setSavedInput(input);
+          }
+
+          // Move up in history
+          const newIndex = historyIndex === -1
+            ? commandHistory.length - 1
+            : Math.max(0, historyIndex - 1);
+
+          setHistoryIndex(newIndex);
+          setInputFn(commandHistory[newIndex]);
+        } else if (e.key === "ArrowDown") {
+          if (historyIndex === -1) return;
+
+          // Move down in history
+          const newIndex = historyIndex + 1;
+          if (newIndex >= commandHistory.length) {
+            // Reached the end of history, restore saved input
+            setHistoryIndex(-1);
+            setInput(savedInput);
+            return;
+          }
+
+          setHistoryIndex(newIndex);
+          setInputFn(commandHistory[newIndex]);
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [commandHistory, historyIndex, input, savedInput]);
+
+  // Function to perform cleanup
+  const performCleanup = async () => {
+    if (kubeconfigPath) {
+      try {
+        console.log("Cleaning up file:", kubeconfigPath); // Debug log
+
+        const response = await fetch("/api/kubectl/cleanup", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({ kubeconfigPath })
+        });
+
+        const result = await response.json();
+
+        if (!response.ok) {
+          console.error("Cleanup failed:", result); // Debug log
+          throw new Error(result.error || "Cleanup failed");
+        }
+
+        if (result.success) {
+          setKubeconfigPath("");
+        } else {
+          console.error("Cleanup was not successful:", result); // Debug log
+        }
+      } catch (error) {
+        console.error("Failed to cleanup kubeconfig:", error);
+      }
+    }
+  };
+
+  // Listen for cleanup event and component unmount
+  useEffect(() => {
+    const handleCleanup = async () => {
+      await performCleanup();
+    };
+
+    window.addEventListener("terminal-cleanup", handleCleanup);
+
+    return () => {
+      window.removeEventListener("terminal-cleanup", handleCleanup);
+      performCleanup(); // Cleanup on unmount
+    };
+  }, [kubeconfigPath]);
+
+  const executeCommand = async (command: string) => {
+    // Add command to history if it's not empty and different from the last command
+    if (command.trim() && (commandHistory.length === 0 || commandHistory[commandHistory.length - 1] !== command)) {
+      setCommandHistory(prev => [...prev, command]);
+    }
+    // Reset history navigation
+    setHistoryIndex(-1);
+    setSavedInput("");
+
+    if (command === "clear") {
+      setOutput([]);
+      return;
+    }
+
+    if (!command.startsWith("kubectl ")) {
+      setOutput(prev => [...prev, "Error: Only kubectl commands are allowed"]);
+      return;
+    }
+
+    try {
+      if (kubeconfig.isLoading) {
+        throw new Error("Kubeconfig is still loading");
+      }
+
+      if (kubeconfig.isError) {
+        throw new Error(`Failed to get kubeconfig: ${kubeconfig.error?.message || "Unknown error"}`);
+      }
+
+      if (!kubeconfig.data) {
+        throw new Error("Kubeconfig data is empty");
+      }
+
+      const response = await fetch("/api/kubectl", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          command,
+          kubeconfig: kubeconfig.data
+        })
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+      }
+
+      const result = await response.json();
+      if (result.kubeconfigPath) {
+        // If there's an existing path, clean it up first
+        if (kubeconfigPath) {
+          await performCleanup();
+        }
+        setKubeconfigPath(result.kubeconfigPath);
+      }
+      setOutput(prev => [...prev, `$ ${command}`, result.output || "Command executed successfully"]);
+    } catch (error) {
+      console.error("Terminal error:", error);
+      setOutput(prev => [...prev, `Error: Failed to execute command`]);
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (input.trim()) {
+      executeCommand(input.trim());
+      setInput("");
+    }
+  };
+
+  // Add click handler for background clicks
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const terminalContainer = document.getElementById('kamaji-terminal-container');
+      const clickedElement = event.target as HTMLElement;
+
+      if (!terminalContainer?.contains(clickedElement)) {
+        const cleanupEvent = new CustomEvent('terminal-cleanup');
+        window.dispatchEvent(cleanupEvent);
+        onClose?.();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [onClose]);
+
+  return (
+    <div 
+      ref={terminalRef}
+      className="h-full flex flex-col text-white font-mono relative"
+    >
+      {kubeconfig.isLoading && (
+        <div className="text-yellow-400 px-4 py-2">Loading kubeconfig...</div>
+      )}
+      {kubeconfig.isError && (
+        <div className="text-red-400 px-4 py-2">
+          Error loading kubeconfig: {kubeconfig.error?.message}
+        </div>
+      )}
+      <div
+        ref={outputRef}
+        className="flex-1 overflow-auto px-4 py-2 mr-2 scroll-smooth terminal-scrollbar"
+        style={{
+          paddingRight: "20px"
+        }}
+      >
+        {output.map((line, i) => (
+          <div key={i} className="whitespace-pre-wrap leading-6">{line}</div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="flex px-4 py-2 border-t border-gray-700">
+        <span className="mr-2 text-gray-400">$</span>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="flex-1 bg-transparent outline-none"
+          placeholder="kubectl command... (or 'clear' to reset terminal, Ctrl+L to clear)"
+        />
+      </form>
+    </div>
+  );
+}

--- a/src/components/ui/toolbar.tsx
+++ b/src/components/ui/toolbar.tsx
@@ -45,7 +45,7 @@ export function ToolBarContainer() {
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="fixed inset-0 bg-gray-600 bg-opacity-75" />
+            <div className="fixed inset-0 bg-gray-600 bg-opacity-75 max-w-4xl" />
           </Transition.Child>
           <Transition.Child
             as={Fragment}


### PR DESCRIPTION
![2025-03-19 19-58-51](https://github.com/user-attachments/assets/2747e2dc-e2e3-451c-856d-bb5ca9dd7c13)

Implemented an action to launch a local process with the Tenant Control Plane `kubeconfig` and interact with the Tenant Control Plane API Server.

Since it doesn't rely on WebSocket, `kubectl logs -f` and `kubectl exec -it` is not supported.